### PR TITLE
Remove the need to export the EmbedFS templates

### DIFF
--- a/controllers/mosquitto_controller.go
+++ b/controllers/mosquitto_controller.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/opdev/mosquitto-operator/api/v1alpha1"
 	"github.com/opdev/mosquitto-operator/internal/reconcilers"
-	"github.com/opdev/mosquitto-operator/internal/templates"
 
 	"github.com/opdev/subreconciler"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -50,11 +49,9 @@ func (r *MosquittoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return *r, err
 	}
 
-	fs := templates.Templates
-
 	subreconcilers := []subreconciler.Fn{
-		reconcilers.ReconcileConfigMap(&mosquitto, r.Client, fs),
-		reconcilers.ReconcileDeployment(&mosquitto, r.Client, fs),
+		reconcilers.ReconcileConfigMap(&mosquitto, r.Client),
+		reconcilers.ReconcileDeployment(&mosquitto, r.Client),
 	}
 
 	for _, r := range subreconcilers {

--- a/internal/reconcilers/configmap.go
+++ b/internal/reconcilers/configmap.go
@@ -2,7 +2,6 @@ package reconcilers
 
 import (
 	"context"
-	"io/fs"
 
 	"github.com/opdev/mosquitto-operator/api/v1alpha1"
 	"github.com/opdev/mosquitto-operator/internal/templates"
@@ -12,9 +11,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ReconcileConfigMap(mosquitto *v1alpha1.Mosquitto, client client.Client, fs fs.ReadFileFS) subreconciler.Fn {
+func ReconcileConfigMap(mosquitto *v1alpha1.Mosquitto, client client.Client) subreconciler.Fn {
 	return func(ctx context.Context) (*ctrl.Result, error) {
-		configmap, err := templates.ResourceFromTemplate[v1alpha1.Mosquitto, corev1.ConfigMap](mosquitto, "configmap", fs)
+		configmap, err := templates.ResourceFromTemplate[v1alpha1.Mosquitto, corev1.ConfigMap](mosquitto, "configmap")
 		if err != nil {
 			return subreconciler.RequeueWithError(err)
 		}

--- a/internal/reconcilers/deployment.go
+++ b/internal/reconcilers/deployment.go
@@ -2,7 +2,6 @@ package reconcilers
 
 import (
 	"context"
-	"io/fs"
 
 	"github.com/opdev/mosquitto-operator/api/v1alpha1"
 	"github.com/opdev/mosquitto-operator/internal/templates"
@@ -13,9 +12,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ReconcileDeployment(mosquitto *v1alpha1.Mosquitto, client client.Client, fs fs.ReadFileFS) subreconciler.Fn {
+func ReconcileDeployment(mosquitto *v1alpha1.Mosquitto, client client.Client) subreconciler.Fn {
 	return func(ctx context.Context) (*ctrl.Result, error) {
-		deployment, err := templates.ResourceFromTemplate[v1alpha1.Mosquitto, appsv1.Deployment](mosquitto, "deployment", fs)
+		deployment, err := templates.ResourceFromTemplate[v1alpha1.Mosquitto, appsv1.Deployment](mosquitto, "deployment")
 		if err != nil {
 			return subreconciler.RequeueWithError(err)
 		}

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -4,17 +4,16 @@ import (
 	"bytes"
 	"embed"
 	"fmt"
-	"io/fs"
 	"text/template"
 
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 //go:embed *.yaml
-var Templates embed.FS
+var templates embed.FS
 
-func ResourceFromTemplate[T any, R any](t *T, name string, fs fs.ReadFileFS) (*R, error) {
-	resYaml, err := fs.ReadFile(fmt.Sprintf("%s.yaml", name))
+func ResourceFromTemplate[T any, R any](t *T, name string) (*R, error) {
+	resYaml, err := templates.ReadFile(fmt.Sprintf("%s.yaml", name))
 	if err != nil {
 		return nil, fmt.Errorf("could not read %s template: %v", name, err)
 	}


### PR DESCRIPTION
Minor improvement. Templates don't need to be exported and passed to the controller.